### PR TITLE
TextFlagCursor text color fix based on theme

### DIFF
--- a/src/components/examples/TextFlagCursorExample.tsx
+++ b/src/components/examples/TextFlagCursorExample.tsx
@@ -1,13 +1,14 @@
-import { DocumentLayout } from "@/components/common/DocumentLayout";
-import { ComponentCard } from "@/components/common/ComponentCard";
 import { CodeExample } from "@/components/common/CodeExample";
+import { ComponentCard } from "@/components/common/ComponentCard";
+import { DocumentLayout } from "@/components/common/DocumentLayout";
 import { LivePreviewCard } from "@/components/common/LivePreviewCard";
+import { TextFlagCursorCode } from "@/constants/constant-hooks";
 import BreadcrumbMaker from "../common/Breadcrumb";
 import TextFlagCursor from "../cursor/common/TextFlagCursor";
-import { TextFlagCursorCode } from "@/constants/constant-hooks";
+import { useTheme } from "@/providers/theme-provider";
 
 const TextFlagCursorExample = () => {
-
+     const { theme } = useTheme();
      return (
           <DocumentLayout
                title="TextFlag Cursor"
@@ -27,7 +28,7 @@ const TextFlagCursorExample = () => {
                          {/* Example with options */}
                          <TextFlagCursor
                               text="Hello World"
-                              color="#000000"
+                              color={theme === "dark" ? "#FFFFFF" : "#000000"}
                               font="monospace"
                               textSize={12}
                          />


### PR DESCRIPTION
Issue: text color was same for both themes.

Dark Theme:
![image](https://github.com/user-attachments/assets/5b79492c-8c30-4b6e-98cf-1a8e0aa54218)

Light Theme:
![image](https://github.com/user-attachments/assets/cb43c1fb-5d14-4054-a11a-6fbc4579570d)
